### PR TITLE
fix: add short names of emojis to search keywords

### DIFF
--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -33,7 +33,8 @@ const buildSearch = (emoji) => {
     })
   }
 
-  addToSearch(emoji.short_names, true)
+  addToSearch(emoji.short_names, true) // this splits the keyword if it has more than one word
+  addToSearch(emoji.short_names, false) // this add the short names as is so they are also searchable
   addToSearch(emoji.name, true)
   addToSearch(emoji.keywords, false)
   addToSearch(emoji.emoticons, false)


### PR DESCRIPTION
Some emojis like `dark_sunglasses` is not found when there is an underscore, this fixed that.

Tracked internally at https://linear.app/texts/issue/TXT-987/emoji-search-doesnt-work-when-is-included